### PR TITLE
Improve offline demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
 # roboadivser
+
+간단한 로보 어드바이저 예제입니다. 시나리오 기반 투자와 특징 검색 기능을 간단하게 체험할 수 있는 웹 인터페이스를 제공합니다.
+
+## 실행 방법 (Colab)
+1. 새로운 Colab 노트를 열고 아래 명령을 실행해 저장소를 클론합니다.
+   기본 브랜치에는 예제 코드가 없으므로 `codex/모의투자-웹-애플리케이션-개발` 브랜치를 지정해 클론합니다.
+```python
+!git clone --single-branch --branch "codex/모의투자-웹-애플리케이션-개발" https://github.com/wdkq2/roboadivser.git
+%cd roboadivser
+```
+다음 명령으로 파일 목록을 확인했을 때 `requirements.txt` 가 보이지 않는다면
+올바른 브랜치를 클론하지 않은 것이므로 다시 클론해야 합니다.
+```python
+!ls
+```
+2. 필요한 패키지를 설치합니다. 위에서 `requirements.txt` 가 보이는 위치에서 실행하세요.
+```python
+!pip install -r requirements.txt
+```
+3. 앱을 실행합니다. `share=True` 옵션이 적용되어 실행 후 공개 링크가 표시됩니다.
+```python
+!python app.py
+```
+   셀이 실행된 상태를 유지한 채로 "Running on public URL" 다음에 나타나는 링크를 
+   클릭하면 웹 인터페이스를 확인할 수 있습니다.
+
+## 주요 기능
+- **시나리오 투자 탭**: 시나리오 내용과 투자 금액, 뉴스 검색 키워드를 입력하면 시나리오가 기록됩니다. "최신 뉴스 확인" 버튼을 누르면 해당 키워드로 구글 뉴스를 검색해 상위 기사 제목과 링크를 보여줍니다.
+- **특징 검색 탭**: 자연어로 작성된 프롬프트를 해석한 뒤 사용자에게 확인을 받고,
+   확인되면 샘플 DART 데이터를 검색해 회사를 제시합니다. 네트워크 제한 때문에 실제 DART 호출은 포함하지 못하지만, 필요하다면 함수를 수정해 개인 API를 호출할 수 있습니다.
+
+API 키가 있다면 실행 전에 다음 환경 변수를 설정하여 뉴스를 검색하고 DART, 매매 API 예시 코드를 테스트할 수 있습니다. 기본값은 각각 `4bada9597f370d2896444b492c3a92ff9c2d8f96` 와 `PShKdxdOkJXLjBKTVLAbh2c2V5RrX3klIRXv` 로 설정되어 있습니다.
+```python
+import os
+os.environ["NEWS_API_KEY"] = "<뉴스 API 키>"  # 선택 사항
+os.environ["DART_API_KEY"] = "4bada9597f370d2896444b492c3a92ff9c2d8f96"
+os.environ["TRADE_API_KEY"] = "PShKdxdOkJXLjBKTVLAbh2c2V5RrX3klIRXv"
+```
+
+매매 버튼을 누르면 금액이 포트폴리오에 기록됩니다. 실제 증권사 API를 호출하지 않는 모의 매매 방식이므로 학습용으로 활용하세요.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,195 @@
+import os
+import re
+import gradio as gr
+import requests
+import xml.etree.ElementTree as ET
+from datetime import datetime
+import threading
+import schedule
+import time
+
+DART_API_KEY = (
+    os.getenv("DART_API_KEY")
+    or "4bada9597f370d2896444b492c3a92ff9c2d8f96"
+)
+TRADE_API_KEY = (
+    os.getenv("TRADE_API_KEY")
+    or "PShKdxdOkJXLjBKTVLAbh2c2V5RrX3klIRXv"
+)
+
+scenarios = []
+news_log = []
+portfolio = {}
+
+# sample financial data for dividend yield calculation (예시)
+sample_financials = [
+    {"corp_name": "삼성전자", "symbol": "005930", "corp_code": "005930", "dps": 361, "price": 70000},
+    {"corp_name": "현대차", "symbol": "005380", "corp_code": "005380", "dps": 3000, "price": 200000},
+    {"corp_name": "NAVER", "symbol": "035420", "corp_code": "035420", "dps": 667, "price": 150000},
+    {"corp_name": "카카오", "symbol": "035720", "corp_code": "035720", "dps": 0, "price": 60000},
+    {"corp_name": "LG화학", "symbol": "051910", "corp_code": "051910", "dps": 12000, "price": 350000},
+]
+
+# analyzed query state
+analysis_state = {}
+
+# Add scenario and record investment
+
+def add_scenario(desc, amount, keywords, symbol):
+    scenario = {
+        "desc": desc,
+        "amount": amount,
+        "keywords": keywords,
+        "symbol": symbol,
+        "time": datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    }
+    scenarios.append(scenario)
+    schedule.every().day.at("08:00").do(check_news, scenario)
+    return (
+        f"Scenario added:\n{desc}\nInvest: {amount} in {symbol}\n"
+        f"Keywords: {keywords}\nPress '매매 실행' to trade"
+    )
+
+# Fetch latest news from Google News
+
+def fetch_news(keywords):
+    """Return the top 3 news articles for the given keywords."""
+    api_key = os.getenv("NEWS_API_KEY")
+    if api_key:
+        url = (
+            f"https://newsapi.org/v2/everything?q={keywords}&language=en&sortBy=publishedAt&apiKey={api_key}"
+        )
+        try:
+            r = requests.get(url, timeout=10)
+            data = r.json()
+        except Exception as e:
+            return f"Request error: {e}"
+        articles = data.get("articles", [])[:3]
+        if not articles:
+            return "No news found"
+        return "\n\n".join(
+            f"{a.get('title')}\n{a.get('url')}" for a in articles
+        )
+    url = "https://news.google.com/rss/search"
+    params = {"q": keywords, "hl": "en-US", "gl": "US", "ceid": "US:en"}
+    try:
+        r = requests.get(url, params=params, headers={"User-Agent": "Mozilla/5.0"}, timeout=10)
+    except Exception as e:
+        return f"Request error: {e}"
+    root = ET.fromstring(r.text)
+    items = root.findall("./channel/item")
+    output = []
+    for item in items[:3]:
+        title = item.findtext("title", default="")
+        link = item.findtext("link", default="")
+        output.append(f"{title}\n{link}")
+    return "\n\n".join(output) if output else "No news found"
+
+
+def check_news(scenario):
+    news = fetch_news(scenario["keywords"])
+    news_log.append({"scenario": scenario["desc"], "news": news, "time": datetime.now().strftime("%Y-%m-%d %H:%M:%S")})
+    print(f"News update for {scenario['desc']}:\n{news}")
+
+
+def run_scheduler():
+    while True:
+        schedule.run_pending()
+        time.sleep(1)
+
+# Simple feature query interpretation (placeholder)
+
+def analyze_query(query):
+    """Very naive interpretation of a natural language query."""
+    m = re.search(r"배당률.*?(\d+)\D*위", query)
+    if m:
+        n = int(m.group(1))
+        analysis_state['query'] = query
+        analysis_state['type'] = 'dividend'
+        analysis_state['count'] = n
+        return f"배당률 상위 {n}개 기업을 찾습니다. 맞습니까?"
+    if "자사주" in query and "소각" in query:
+        analysis_state['query'] = query
+        analysis_state['type'] = 'buyback'
+        return "자사주 보유가 많고 소각하지 않는 회사를 찾습니다. 맞습니까?"
+    return "요청을 이해하지 못했습니다."
+
+def dividend_rank(n):
+    ranked = sorted(
+        sample_financials,
+        key=lambda x: (x['dps'] / x['price'] if x['price'] else 0),
+        reverse=True,
+    )
+    out = []
+    for comp in ranked[:n]:
+        pct = comp['dps'] / comp['price'] * 100 if comp['price'] else 0
+        out.append(f"{comp['corp_name']}({comp['symbol']}): {pct:.2f}%")
+    return "\n".join(out)
+
+# Provide example results for feature search
+
+def get_dart_data(query):
+    """Return company info from sample data matching the query."""
+    results = []
+    for item in sample_financials:
+        if query in item["corp_name"]:
+            results.append(f"{item['corp_name']} ({item['corp_code']})")
+    return "\n".join(results) if results else "No results"
+
+
+def execute_trade(symbol, amount):
+    """Record a mock trade locally."""
+    try:
+        amt = float(amount)
+    except ValueError:
+        return "Invalid amount"
+    portfolio[symbol] = portfolio.get(symbol, 0) + amt
+    return f"매매 완료: {symbol} {amt}원 보유량 {portfolio[symbol]}원"
+
+
+def example_results(query):
+    """Return search results using sample DART data."""
+    return get_dart_data(query)
+
+def perform_query(_=None):
+    if analysis_state.get('type') == 'dividend':
+        n = analysis_state.get('count', 0)
+        return dividend_rank(n)
+    elif analysis_state.get('type') == 'buyback':
+        return "자사주 보유량 데이터 예시"
+    return "분석된 내용이 없습니다."
+
+with gr.Blocks() as demo:
+    gr.Markdown("## 간단한 로보 어드바이저 예제")
+    with gr.Tab("시나리오 투자"):
+        scenario_text = gr.Textbox(label="시나리오 내용")
+        amount = gr.Textbox(label="투자 금액 (원)")
+        symbol = gr.Textbox(label="종목 코드")
+        keywords = gr.Textbox(label="뉴스 검색 키워드")
+        add_btn = gr.Button("시나리오 추가")
+        scenario_out = gr.Textbox(label="상태")
+        add_btn.click(add_scenario, [scenario_text, amount, keywords, symbol], scenario_out)
+        trade_btn = gr.Button("매매 실행")
+        trade_result = gr.Textbox(label="매매 결과")
+        trade_btn.click(execute_trade, [symbol, amount], trade_result)
+        news_btn = gr.Button("최신 뉴스 확인")
+        news_out = gr.Textbox(label="뉴스 결과")
+        news_btn.click(fetch_news, keywords, news_out)
+    with gr.Tab("특징 검색"):
+        feature_query = gr.Textbox(label="검색 프롬프트")
+        analyze_btn = gr.Button("프롬프트 해석")
+        analysis = gr.Textbox(label="해석 결과")
+        analyze_btn.click(analyze_query, feature_query, analysis)
+        confirm_btn = gr.Button("해석 확인")
+        cancel_btn = gr.Button("취소")
+        results = gr.Textbox(label="검색 결과")
+        confirm_btn.click(perform_query, None, results)
+        cancel_btn.click(lambda: "취소되었습니다.", None, results)
+
+    gr.Markdown(
+        "NEWS_API_KEY가 있으면 뉴스API를 사용하고, DART_API_KEY와 TRADE_API_KEY는 기본값이 제공되어 바로 테스트할 수 있습니다."
+    )
+
+if __name__ == "__main__":
+    threading.Thread(target=run_scheduler, daemon=True).start()
+    demo.launch(share=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+requests
+beautifulsoup4
+gradio
+schedule


### PR DESCRIPTION
## Summary
- clarify sample DART search behavior and mock trade in README
- simulate DART data and trading in `app.py`
- store trades locally using `portfolio`

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt`
- `python - <<'PY'
from app import fetch_news, dividend_rank, get_dart_data, execute_trade
print('news:', fetch_news('tesla')[:80])
print('dividend', dividend_rank(2))
print('dart', get_dart_data('삼성'))
print(execute_trade('005930', '100000'))
PY`

------
https://chatgpt.com/codex/tasks/task_e_684ed0538a1c83218b115fb645a40f67